### PR TITLE
libhb: disable dovi passthrough for SVT AV1

### DIFF
--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1560,8 +1560,9 @@ static void sanitize_dynamic_hdr_metadata_passthru(hb_job_t *job)
          job->dovi.dv_profile != 8 &&
          job->dovi.dv_profile != 10) ||
         (job->vcodec != HB_VCODEC_X265_10BIT &&
-         job->vcodec != HB_VCODEC_VT_H265_10BIT &&
-         job->vcodec != HB_VCODEC_SVT_AV1_10BIT))
+         job->vcodec != HB_VCODEC_VT_H265_10BIT
+        //  && job->vcodec != HB_VCODEC_SVT_AV1_10BIT
+         ))
     {
         job->passthru_dynamic_hdr_metadata &= ~DOVI;
     }


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**





**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
